### PR TITLE
Fixed any syntax definition

### DIFF
--- a/Sources/CodableMacroPlugin/Registration/Registrar.swift
+++ b/Sources/CodableMacroPlugin/Registration/Registrar.swift
@@ -278,7 +278,10 @@ private extension InitializerDeclSyntax {
         let decoder: TokenSyntax = "decoder"
         let param = FunctionParameterSyntax(
             firstName: "from", secondName: decoder,
-            type: IdentifierTypeSyntax(name: "any Decoder")
+            type: SomeOrAnyTypeSyntax(
+              someOrAnySpecifier: .keyword(.any),
+              constraint: IdentifierTypeSyntax(name: "Decoder")
+            )
         )
 
         let signature = FunctionSignatureSyntax(
@@ -317,7 +320,10 @@ private extension FunctionDeclSyntax {
         let encoder: TokenSyntax = "encoder"
         let param = FunctionParameterSyntax(
             firstName: "to", secondName: encoder,
-            type: IdentifierTypeSyntax(name: "any Encoder")
+            type: SomeOrAnyTypeSyntax(
+              someOrAnySpecifier: .keyword(.any),
+              constraint: IdentifierTypeSyntax(name: "Encoder")
+            )
         )
 
         let signature = FunctionSignatureSyntax(


### PR DESCRIPTION
I would like #29 to land to fix #27, so this fixes the any syntax and uses the appropriate SomeOrAnyTypeSyntax(someOrAnySpecifier:, constraint:).

This addresses the following comments: [1](https://github.com/SwiftyLab/MetaCodable/pull/29#discussion_r1357915308) and [2](https://github.com/SwiftyLab/MetaCodable/pull/29#discussion_r1357915764)